### PR TITLE
fix(ci): pre-cache NLI model to fix flaky tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,12 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
 
+      - name: Pre-cache NLI model
+        run: |
+          python3 -c "from huggingface_hub import snapshot_download; snapshot_download('cross-encoder/nli-deberta-v3-small')"
+
       - name: Build
         run: cargo build --release
 
       - name: Test
-        run: cargo test --release
+        run: cargo test --release -- --test-threads=4


### PR DESCRIPTION
Fix intermittent NLI test failures caused by concurrent model download.

## Problem
- NLI tests fail ~50% of the time with lock acquisition errors
- Multiple test threads download same HuggingFace model concurrently
- HuggingFace Hub lock file acquisition fails when contested
- Tests affected: `test_model_inputs`, `test_scores_to_rel_contradiction`

## Solution
Pre-download NLI model in CI workflow setup step (before tests).
This prevents concurrent download attempts during test execution.

## Implementation
- Add 'Pre-cache NLI model' step before cargo build
- Uses HuggingFace Hub snapshot_download() with Python 3
- Uses default HF_HOME (~/.cache/huggingface)
- Fails hard if model download fails (strict mode)
- Tests run with --test-threads=4 to verify concurrent access

## Why This Approach
- **Simple**: Single Python command, no code changes needed
- **Fast**: Model cached before build, reused by all tests
- **Reliable**: Eliminates lock contention during test execution
- **Reversible**: Easy to remove if needed

## Expected Result
- Consistent CI runs (no more ~50% flakiness)
- All tests pass with concurrent execution (--test-threads=4)
- Lock acquisition errors eliminated

Closes TODO-adbdd6b3