### PR TITLE
feat: add stdio MCP server to voidm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,8 +616,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -635,12 +645,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.117",
 ]
@@ -680,7 +715,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -766,6 +801,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -2608,6 +2649,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,6 +2761,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5947688160b56fb6c827e3c20a72c90392a1d7e9dec74749197aa1780ac42ca"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "paste",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01263441d3f8635c628e33856c468b96ebbce1af2d3699ea712ca71432d4ee7a"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,6 +2884,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,6 +2968,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3912,6 +4044,7 @@ dependencies = [
  "clap",
  "colored",
  "comfy-table",
+ "rmcp",
  "serde",
  "serde_json",
  "sqlx",

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Local-first persistent memory for LLM agents.
 - **Auto-init** — DB created on first write, no setup step
 - **Short IDs** — use any 4+ char UUID prefix instead of full IDs
 - **JSON output** — every command supports `--json` for agent consumption
+- **MCP server** — expose assistant-friendly memory and ontology tools/resources over stdio with `voidm mcp`
 
 ---
 
@@ -68,6 +69,42 @@ voidm add "Run rake db:migrate then restart puma" --type procedural --scope work
 voidm search "deployment"
 voidm search "database" --scope work/acme --mode semantic
 voidm search "migration" --min-score 0 --limit 20 --json
+```
+
+### MCP server
+
+Expose a small assistant-focused subset of `voidm` as an MCP server over stdio:
+
+```bash
+voidm mcp --transport stdio
+```
+
+This is intended for MCP clients such as `mcporter` and other assistants. v1 exposes assistant-friendly tools for:
+- searching memories
+- storing memories (with `quality_score` and warnings)
+- deleting memories
+- linking memories
+- searching, listing, getting, and creating concepts
+- linking memories to concepts
+- linking concepts together
+
+It also exposes read-only MCP resources for recent memories/concepts and item-by-id reads.
+
+Example with `mcporter`:
+
+```bash
+npx -y mcporter list \
+  --stdio ./target/debug/voidm \
+  --stdio-arg mcp \
+  --stdio-arg --transport \
+  --stdio-arg stdio
+
+npx -y mcporter call \
+  --stdio ./target/debug/voidm \
+  --stdio-arg mcp \
+  --stdio-arg --transport \
+  --stdio-arg stdio \
+  search_concepts query=docker --output json
 ```
 
 Filter by quality score (0.0-1.0, added automatically):

--- a/crates/voidm-cli/Cargo.toml
+++ b/crates/voidm-cli/Cargo.toml
@@ -28,3 +28,4 @@ toml             = { workspace = true }
 anyhow           = { workspace = true }
 tracing          = { workspace = true }
 tracing-subscriber = { workspace = true }
+rmcp = { version = "0.8.0", features = ["server", "macros", "transport-io", "schemars"] }

--- a/crates/voidm-cli/src/commands/mcp.rs
+++ b/crates/voidm-cli/src/commands/mcp.rs
@@ -1,0 +1,645 @@
+use anyhow::{Result, anyhow};
+use rmcp::{
+    Json, ServerHandler, ServiceExt, tool, tool_handler, tool_router,
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{
+        AnnotateAble, ListResourceTemplatesResult, ListResourcesResult, PaginatedRequestParam,
+        RawResource, RawResourceTemplate, ReadResourceRequestParam, ReadResourceResult,
+        ResourceContents, ServerCapabilities, ServerInfo,
+    },
+    schemars,
+    schemars::JsonSchema,
+};
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+use sqlx::SqlitePool;
+use voidm_core::{
+    Config, crud,
+    models::{AddMemoryRequest, EdgeType, LinkSpec, MemoryType},
+    ontology::{self, NodeKind, OntologyRelType},
+    resolve_id,
+    search::{SearchMode, SearchOptions, search},
+};
+
+#[derive(clap::Args, Clone)]
+pub struct McpArgs {
+    #[arg(long, default_value = "stdio")]
+    pub transport: String,
+}
+
+pub async fn run(args: McpArgs, pool: SqlitePool, config: Config) -> Result<()> {
+    if args.transport != "stdio" {
+        anyhow::bail!("Unsupported transport '{}'. v1 supports only --transport stdio", args.transport);
+    }
+
+    let server = VoidmMcpServer::new(pool, config);
+    let running = server.serve(rmcp::transport::stdio()).await?;
+    running.waiting().await?;
+    Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct VoidmMcpServer {
+    pool: SqlitePool,
+    config: Config,
+    tool_router: ToolRouter<Self>,
+}
+
+impl VoidmMcpServer {
+    fn new(pool: SqlitePool, config: Config) -> Self {
+        Self {
+            pool,
+            config,
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    fn server_info() -> ServerInfo {
+        ServerInfo {
+            protocol_version: Default::default(),
+            capabilities: ServerCapabilities::builder()
+                .enable_tools()
+                .enable_resources()
+                .build(),
+            server_info: rmcp::model::Implementation {
+                name: "voidm".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                title: None,
+                icons: None,
+                website_url: None,
+            },
+            instructions: Some("Assistant-focused memory and ontology access for voidm".to_string()),
+        }
+    }
+
+    fn raw_resource(uri: String, name: String, description: &str) -> RawResource {
+        RawResource {
+            uri,
+            name,
+            title: None,
+            description: Some(description.to_string()),
+            mime_type: Some("application/json".to_string()),
+            size: None,
+            icons: None,
+        }
+    }
+
+    fn raw_template(uri_template: &str, name: &str, description: &str) -> RawResourceTemplate {
+        RawResourceTemplate {
+            uri_template: uri_template.to_string(),
+            name: name.to_string(),
+            title: None,
+            description: Some(description.to_string()),
+            mime_type: Some("application/json".to_string()),
+        }
+    }
+}
+
+#[tool_handler(router = self.tool_router)]
+impl ServerHandler for VoidmMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        Self::server_info()
+    }
+
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParam>,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> std::result::Result<ListResourcesResult, rmcp::ErrorData> {
+        let memories = crud::list_memories(&self.pool, None, None, 20)
+            .await
+            .map_err(mcp_err)?;
+        let concepts = ontology::list_concepts(&self.pool, None, 20)
+            .await
+            .map_err(mcp_err)?;
+
+        let mut resources = vec![
+            Self::raw_resource(
+                "voidm://memories/recent".to_string(),
+                "memories/recent".to_string(),
+                "Recent memory records",
+            )
+            .no_annotation(),
+            Self::raw_resource(
+                "voidm://concepts".to_string(),
+                "concepts".to_string(),
+                "Recent concept records",
+            )
+            .no_annotation(),
+        ];
+
+        resources.extend(memories.into_iter().map(|m| {
+            Self::raw_resource(
+                format!("voidm://memory/{}", m.id),
+                format!("memory/{}", m.id),
+                "Voidm memory record",
+            )
+            .no_annotation()
+        }));
+        resources.extend(concepts.into_iter().map(|c| {
+            Self::raw_resource(
+                format!("voidm://concept/{}", c.id),
+                format!("concept/{}", c.id),
+                "Voidm concept record",
+            )
+            .no_annotation()
+        }));
+
+        Ok(ListResourcesResult {
+            resources,
+            next_cursor: None,
+        })
+    }
+
+    async fn list_resource_templates(
+        &self,
+        _request: Option<PaginatedRequestParam>,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> std::result::Result<ListResourceTemplatesResult, rmcp::ErrorData> {
+        Ok(ListResourceTemplatesResult {
+            resource_templates: vec![
+                Self::raw_template("voidm://memory/{id}", "memory", "Fetch a memory as JSON").no_annotation(),
+                Self::raw_template("voidm://concept/{id}", "concept", "Fetch a concept as JSON").no_annotation(),
+            ],
+            next_cursor: None,
+        })
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParam,
+        _context: rmcp::service::RequestContext<rmcp::RoleServer>,
+    ) -> std::result::Result<ReadResourceResult, rmcp::ErrorData> {
+        let uri = request.uri;
+        let value = if uri == "voidm://memories/recent" {
+            json!(crud::list_memories(&self.pool, None, None, 20).await.map_err(mcp_err)?)
+        } else if uri == "voidm://concepts" {
+            json!(ontology::list_concepts(&self.pool, None, 20).await.map_err(mcp_err)?)
+        } else if let Some(id) = uri.strip_prefix("voidm://memory/") {
+            let id = resolve_id(&self.pool, id).await.map_err(mcp_err)?;
+            let memory = crud::get_memory(&self.pool, &id)
+                .await
+                .map_err(mcp_err)?
+                .ok_or_else(|| mcp_err(anyhow!("Memory not found: {id}")))?;
+            json!(memory)
+        } else if let Some(id) = uri.strip_prefix("voidm://concept/") {
+            let concept = ontology::get_concept_with_instances(&self.pool, id).await.map_err(mcp_err)?;
+            json!(concept)
+        } else {
+            return Err(mcp_err(anyhow!("Unknown resource URI: {uri}")));
+        };
+
+        Ok(ReadResourceResult {
+            contents: vec![ResourceContents::text(
+                serde_json::to_string_pretty(&value)
+                    .map_err(|e| mcp_err(anyhow!(e.to_string())))?,
+                uri,
+            )],
+        })
+    }
+}
+
+#[tool_router(router = tool_router)]
+impl VoidmMcpServer {
+    #[tool(name = "search_memories", description = "Search memories with optional scope, type, mode and quality filters")]
+    async fn search_memories(
+        &self,
+        Parameters(params): Parameters<SearchMemoriesParams>,
+    ) -> std::result::Result<Json<Map<String, Value>>, String> {
+        let mode: SearchMode = params.mode.parse().map_err(|e: anyhow::Error| e.to_string())?;
+        let opts = SearchOptions {
+            query: params.query,
+            mode,
+            limit: params.limit,
+            scope_filter: params.scope,
+            type_filter: params.memory_type,
+            min_score: params.min_score,
+            min_quality: params.min_quality,
+            include_neighbors: false,
+            neighbor_depth: None,
+            neighbor_decay: None,
+            neighbor_min_score: None,
+            neighbor_limit: None,
+            edge_types: None,
+        };
+
+        let resp = search(
+            &self.pool,
+            &opts,
+            &self.config.embeddings.model,
+            self.config.embeddings.enabled,
+            self.config.search.min_score,
+            &self.config.search,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+
+        let mut out = Map::new();
+        out.insert("results".to_string(), json!(resp.results));
+        out.insert("best_score".to_string(), json!(resp.best_score));
+        out.insert("threshold_applied".to_string(), json!(resp.threshold_applied));
+        Ok(Json(out))
+    }
+
+    #[tool(name = "remember", description = "Store a memory and return quality score and warnings")]
+    async fn remember(
+        &self,
+        Parameters(params): Parameters<RememberParams>,
+    ) -> std::result::Result<Json<Map<String, Value>>, String> {
+        let memory_type: MemoryType = params.memory_type.parse().map_err(|e: anyhow::Error| e.to_string())?;
+        let importance = params.importance.unwrap_or(5);
+        if !(1..=10).contains(&importance) {
+            return Err("importance must be between 1 and 10".to_string());
+        }
+
+        let links = params
+            .links
+            .unwrap_or_default()
+            .into_iter()
+            .map(|l| {
+                let edge_type: EdgeType = l.rel.parse().map_err(|e: anyhow::Error| e.to_string())?;
+                Ok(LinkSpec {
+                    target_id: l.target_id,
+                    edge_type,
+                    note: l.note,
+                })
+            })
+            .collect::<std::result::Result<Vec<_>, String>>()?;
+
+        let req = AddMemoryRequest {
+            content: params.content,
+            memory_type,
+            scopes: params.scope,
+            tags: params.tags.unwrap_or_default(),
+            importance,
+            metadata: serde_json::Value::Object(Default::default()),
+            links,
+        };
+
+        let resp = crud::add_memory(&self.pool, req, &self.config)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let warnings = memory_write_warnings(&resp);
+        let mut out = Map::new();
+        out.insert("memory".to_string(), json!(resp));
+        out.insert("warnings".to_string(), json!(warnings));
+        Ok(Json(out))
+    }
+
+    #[tool(name = "delete_memory", description = "Delete a memory by id or short prefix")]
+    async fn delete_memory(
+        &self,
+        Parameters(params): Parameters<DeleteMemoryParams>,
+    ) -> std::result::Result<Json<Map<String, Value>>, String> {
+        let id = resolve_id(&self.pool, &params.memory_id)
+            .await
+            .map_err(|e| e.to_string())?;
+        let deleted = crud::delete_memory(&self.pool, &id)
+            .await
+            .map_err(|e| e.to_string())?;
+        let mut out = Map::new();
+        out.insert("deleted".to_string(), json!(deleted));
+        out.insert("id".to_string(), json!(id));
+        Ok(Json(out))
+    }
+
+    #[tool(name = "link_memories", description = "Create a relation between two memories")]
+    async fn link_memories(
+        &self,
+        Parameters(params): Parameters<LinkMemoriesParams>,
+    ) -> std::result::Result<Json<Map<String, Value>>, String> {
+        let rel: EdgeType = params.rel.parse().map_err(|e: anyhow::Error| e.to_string())?;
+        let from = resolve_id(&self.pool, &params.from).await.map_err(|e| e.to_string())?;
+        let to = resolve_id(&self.pool, &params.to).await.map_err(|e| e.to_string())?;
+        let resp = crud::link_memories(&self.pool, &from, &rel, &to, params.note.as_deref())
+            .await
+            .map_err(|e| e.to_string())?;
+        let value = serde_json::to_value(resp).map_err(|e| e.to_string())?;
+        match value {
+            Value::Object(map) => Ok(Json(map)),
+            _ => Err("internal error: non-object link response".to_string()),
+        }
+    }
+
+    #[tool(name = "search_concepts", description = "Search concepts by name and description")]
+    async fn search_concepts(
+        &self,
+        Parameters(params): Parameters<SearchConceptsParams>,
+    ) -> std::result::Result<Json<Map<String, Value>>, String> {
+        let results = ontology::search_concepts(
+            &self.pool,
+            &params.query,
+            params.scope.as_deref(),
+            params.limit,
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+        let mut out = Map::new();
+        out.insert("results".to_string(), json!(results));
+        Ok(Json(out))
+    }
+
+    #[tool(name = "list_concepts", description = "List concepts with optional scope filter")]
+    async fn list_concepts(
+        &self,
+        Parameters(params): Parameters<ListConceptsParams>,
+    ) -> std::result::Result<Json<Map<String, Value>>, String> {
+        let results = ontology::list_concepts(&self.pool, params.scope.as_deref(), params.limit)
+            .await
+            .map_err(|e| e.to_string())?;
+        let mut out = Map::new();
+        out.insert("results".to_string(), json!(results));
+        Ok(Json(out))
+    }
+
+    #[tool(name = "get_concept", description = "Get a concept with instances, subclasses and superclasses")]
+    async fn get_concept(
+        &self,
+        Parameters(params): Parameters<GetConceptParams>,
+    ) -> std::result::Result<Json<Map<String, Value>>, String> {
+        let concept = ontology::get_concept_with_instances(&self.pool, &params.id)
+            .await
+            .map_err(|e| e.to_string())?;
+        let value = serde_json::to_value(concept).map_err(|e| e.to_string())?;
+        match value {
+            Value::Object(map) => Ok(Json(map)),
+            _ => Err("internal error: non-object concept response".to_string()),
+        }
+    }
+
+    #[tool(name = "create_concept", description = "Create a concept")]
+    async fn create_concept(
+        &self,
+        Parameters(params): Parameters<CreateConceptParams>,
+    ) -> std::result::Result<Json<Map<String, Value>>, String> {
+        let concept = ontology::add_concept(
+            &self.pool,
+            &params.name,
+            params.description.as_deref(),
+            params.scope.as_deref(),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+        let value = serde_json::to_value(concept).map_err(|e| e.to_string())?;
+        match value {
+            Value::Object(map) => Ok(Json(map)),
+            _ => Err("internal error: non-object concept response".to_string()),
+        }
+    }
+
+    #[tool(name = "link_memory_to_concept", description = "Link a memory to a concept with INSTANCE_OF")]
+    async fn link_memory_to_concept(
+        &self,
+        Parameters(params): Parameters<LinkMemoryToConceptParams>,
+    ) -> std::result::Result<Json<Map<String, Value>>, String> {
+        let from_id = resolve_node_id(&self.pool, &params.memory_id, NodeKind::Memory)
+            .await
+            .map_err(|e| e.to_string())?;
+        let to_id = resolve_node_id(&self.pool, &params.concept_id, NodeKind::Concept)
+            .await
+            .map_err(|e| e.to_string())?;
+        let edge = ontology::add_ontology_edge(
+            &self.pool,
+            &from_id,
+            NodeKind::Memory,
+            &OntologyRelType::InstanceOf,
+            &to_id,
+            NodeKind::Concept,
+            params.note.as_deref(),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+        let value = serde_json::to_value(edge).map_err(|e| e.to_string())?;
+        match value {
+            Value::Object(map) => Ok(Json(map)),
+            _ => Err("internal error: non-object edge response".to_string()),
+        }
+    }
+
+    #[tool(name = "link_concepts", description = "Link two concepts with IS_A or another ontology relation")]
+    async fn link_concepts(
+        &self,
+        Parameters(params): Parameters<LinkConceptsParams>,
+    ) -> std::result::Result<Json<Map<String, Value>>, String> {
+        let rel: OntologyRelType = params.rel.parse().map_err(|e: anyhow::Error| e.to_string())?;
+        let from_id = resolve_node_id(&self.pool, &params.from, NodeKind::Concept)
+            .await
+            .map_err(|e| e.to_string())?;
+        let to_id = resolve_node_id(&self.pool, &params.to, NodeKind::Concept)
+            .await
+            .map_err(|e| e.to_string())?;
+        let edge = ontology::add_ontology_edge(
+            &self.pool,
+            &from_id,
+            NodeKind::Concept,
+            &rel,
+            &to_id,
+            NodeKind::Concept,
+            params.note.as_deref(),
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+        let value = serde_json::to_value(edge).map_err(|e| e.to_string())?;
+        match value {
+            Value::Object(map) => Ok(Json(map)),
+            _ => Err("internal error: non-object edge response".to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct SearchMemoriesParams {
+    query: String,
+    #[serde(default = "default_search_mode")]
+    mode: String,
+    #[serde(default = "default_limit")]
+    limit: usize,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default, rename = "type")]
+    memory_type: Option<String>,
+    #[serde(default)]
+    min_score: Option<f32>,
+    #[serde(default)]
+    min_quality: Option<f32>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct RememberParams {
+    content: String,
+    #[serde(rename = "type")]
+    memory_type: String,
+    #[serde(default)]
+    importance: Option<i64>,
+    #[serde(default)]
+    scope: Vec<String>,
+    #[serde(default)]
+    tags: Option<Vec<String>>,
+    #[serde(default)]
+    links: Option<Vec<LinkSpecInput>>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct LinkSpecInput {
+    target_id: String,
+    rel: String,
+    #[serde(default)]
+    note: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct DeleteMemoryParams {
+    memory_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct LinkMemoriesParams {
+    from: String,
+    rel: String,
+    to: String,
+    #[serde(default)]
+    note: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct SearchConceptsParams {
+    query: String,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default = "default_limit")]
+    limit: usize,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ListConceptsParams {
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default = "default_limit")]
+    limit: usize,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct GetConceptParams {
+    id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct CreateConceptParams {
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct LinkMemoryToConceptParams {
+    memory_id: String,
+    concept_id: String,
+    #[serde(default)]
+    note: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct LinkConceptsParams {
+    from: String,
+    rel: String,
+    to: String,
+    #[serde(default)]
+    note: Option<String>,
+}
+
+fn default_limit() -> usize { 10 }
+fn default_search_mode() -> String { "hybrid".to_string() }
+
+fn memory_write_warnings(resp: &voidm_core::models::AddMemoryResponse) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if let Some(score) = resp.quality_score {
+        if score < 0.5 {
+            warnings.push(format!("Low memory quality score ({score:.2}). Consider rewriting as a more general, timeless principle."));
+        } else if score < 0.7 {
+            warnings.push(format!("Moderate memory quality score ({score:.2}). Consider improving abstraction or removing task-specific language."));
+        }
+    }
+    if let Some(dup) = &resp.duplicate_warning {
+        warnings.push(format!("Possible duplicate of {} (score {:.2}): {}", dup.id, dup.score, dup.message));
+    }
+    warnings
+}
+
+async fn resolve_node_id(pool: &SqlitePool, id: &str, kind: NodeKind) -> Result<String> {
+    match kind {
+        NodeKind::Concept => ontology::resolve_concept_id(pool, id).await,
+        NodeKind::Memory => resolve_id(pool, id).await,
+    }
+}
+
+fn mcp_err(err: anyhow::Error) -> rmcp::ErrorData {
+    rmcp::ErrorData::internal_error(err.to_string(), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_output_schemas_are_objects_for_mcporter() {
+        let tools = VoidmMcpServer::tool_router().list_all();
+        assert!(!tools.is_empty(), "expected MCP tools to be registered");
+
+        for tool in tools {
+            let schema = tool.output_schema.as_ref().expect("tool should expose output schema");
+            assert_eq!(schema.get("type").and_then(|v| v.as_str()), Some("object"), "tool {} should expose an object output schema", tool.name);
+        }
+    }
+
+    #[test]
+    fn remember_tool_input_schema_exposes_required_fields() {
+        let tool = VoidmMcpServer::remember_tool_attr();
+        let required = tool
+            .input_schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .expect("remember input schema should have required fields");
+
+        let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(names.contains(&"content"));
+        assert!(names.contains(&"type"));
+    }
+
+    #[test]
+    fn resources_and_templates_use_voidm_uris() {
+        let memory = VoidmMcpServer::raw_resource(
+            "voidm://memory/abc".to_string(),
+            "memory/abc".to_string(),
+            "memory",
+        );
+        let template = VoidmMcpServer::raw_template("voidm://memory/{id}", "memory", "memory template");
+
+        assert_eq!(memory.uri, "voidm://memory/abc");
+        assert_eq!(template.uri_template, "voidm://memory/{id}");
+        assert_eq!(memory.mime_type.as_deref(), Some("application/json"));
+        assert_eq!(template.mime_type.as_deref(), Some("application/json"));
+    }
+
+    #[test]
+    fn low_quality_scores_produce_warning() {
+        let response = voidm_core::models::AddMemoryResponse {
+            id: "id".to_string(),
+            memory_type: "semantic".to_string(),
+            content: "today I fixed task".to_string(),
+            scopes: vec![],
+            tags: vec![],
+            importance: 5,
+            created_at: "now".to_string(),
+            quality_score: Some(0.4),
+            suggested_links: vec![],
+            duplicate_warning: None,
+        };
+
+        let warnings = memory_write_warnings(&response);
+        assert!(!warnings.is_empty());
+        assert!(warnings[0].contains("Low memory quality score"));
+    }
+}

--- a/crates/voidm-cli/src/commands/mod.rs
+++ b/crates/voidm-cli/src/commands/mod.rs
@@ -16,3 +16,4 @@ pub mod instructions;
 pub mod info;
 pub mod stats;
 pub mod init;
+pub mod mcp;

--- a/crates/voidm-cli/src/main.rs
+++ b/crates/voidm-cli/src/main.rs
@@ -71,6 +71,8 @@ pub enum Commands {
     Info(commands::info::InfoArgs),
     /// Show memory and graph statistics
     Stats(commands::stats::StatsArgs),
+    /// Run an assistant-friendly MCP server
+    Mcp(commands::mcp::McpArgs),
 }
 
 #[tokio::main]
@@ -189,5 +191,6 @@ async fn run(cli: Cli) -> Result<()> {
         Commands::Info(_) => unreachable!(),
         Commands::Init(_) => unreachable!(),
         Commands::Stats(args) => commands::stats::run(args, &pool, &config, cli.json).await,
+        Commands::Mcp(args) => commands::mcp::run(args, pool, config).await,
     }
 }


### PR DESCRIPTION
## Summary
- add `voidm mcp --transport stdio`
- expose assistant-friendly memory and ontology MCP tools/resources
- add MCP schema tests and README usage examples

## Validation
- `cargo check -p voidm-cli`
- `cargo build -p voidm-cli`
- `cargo test -p voidm-cli mcp -- --nocapture`
- `npx -y mcporter list --stdio ./target/debug/voidm --stdio-arg mcp --stdio-arg --transport --stdio-arg stdio --json`
- `npx -y mcporter call --stdio ./target/debug/voidm --stdio-arg mcp --stdio-arg --transport --stdio-arg stdio search_concepts query=docker --output json`
- `npx -y mcporter call --stdio ./target/debug/voidm --stdio-arg mcp --stdio-arg --transport --stdio-arg stdio search_memories query=container --output json`
- `npx -y mcporter call --stdio ./target/debug/voidm --stdio-arg mcp --stdio-arg --transport --stdio-arg stdio remember --args '{"content":"MCP servers should expose assistant-friendly structured outputs with object schemas for compatibility.","type":"semantic","importance":8,"scope":["projects/voidm"],"tags":["mcp","interop"]}' --output json`\n\nCloses #12